### PR TITLE
Refactor navbar into reusable include

### DIFF
--- a/templates/homeApp/index.html
+++ b/templates/homeApp/index.html
@@ -40,33 +40,9 @@
 
         <div class="col-6 mt-5">
 
-          <nav class="nav navbar-expand-lg ">
-            <button class="navbar-toggler custom-custom-toggler custom-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                <i class="bi bi-list icon-white"></i>
-            </button>
-            <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                <ul class="navbar-nav mx-auto mb-2 mb-lg-0 justify-content-center">
-                  <li class="nav-item custom-nav-item me-5">
-                    <a class="nav-link active" aria-current="page" href="#">Home</a>
-                  </li>
-                  <li class="nav-item custom-nav-item me-5">
-                    <a class="nav-link" href="{% url 'research' %}">Research</a>
-                  </li>
-                  <li class="nav-item custom-nav-item me-5">
-                    <a class="nav-link"  href="{% url 'miembros' %}">Members</a>
-                  </li>
-                  <li class="nav-item custom-nav-item me-5">
-                    <a class="nav-link"  href="{% url 'pub' %}">Publications</a>
-                  </li>
-                  <li class="nav-item custom-nav-item me-5">
-                    <a class="nav-link" href="{% url 'news' %}">News</a>
-                  </li>
-                </ul>
-            </div>
-            
-          </nav>
+          {% include 'includes/navbar.html' with active='home' %}
 
-        </div>                
+        </div>
           
       </div>
 

--- a/templates/includes/navbar.html
+++ b/templates/includes/navbar.html
@@ -1,0 +1,26 @@
+<nav class="navbar navbar-expand-lg navbar-dark">
+  <div class="container">
+    <button class="navbar-toggler custom-custom-toggler custom-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <i class="bi bi-list icon-white"></i>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="navbar-nav mx-auto mb-2 mb-lg-0 justify-content-center">
+          <li class="nav-item custom-nav-item me-5">
+            <a class="nav-link {% if active == 'home' %}active{% endif %}" href="{% url 'home' %}">Home</a>
+          </li>
+          <li class="nav-item custom-nav-item me-5">
+            <a class="nav-link {% if active == 'research' %}active{% endif %}" href="{% url 'research' %}">Research</a>
+          </li>
+          <li class="nav-item custom-nav-item me-5">
+            <a class="nav-link {% if active == 'members' %}active{% endif %}" href="{% url 'miembros' %}">Members</a>
+          </li>
+          <li class="nav-item custom-nav-item me-5">
+            <a class="nav-link {% if active == 'publications' %}active{% endif %}" href="{% url 'pub' %}">Publications</a>
+          </li>
+          <li class="nav-item custom-nav-item me-5">
+            <a class="nav-link {% if active == 'news' %}active{% endif %}" href="{% url 'news' %}">News</a>
+          </li>
+        </ul>
+    </div>
+  </div>
+</nav>

--- a/templates/members/addMembers.html
+++ b/templates/members/addMembers.html
@@ -40,31 +40,7 @@
         <div class="row justify-content-center">
           <div class="col mt-3">
 
-            <nav class="nav navbar-expand-lg ">
-              <button class="navbar-toggler custom-custom-toggler custom-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                  <i class="bi bi-list icon-white"></i>
-              </button>
-              <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                  <ul class="navbar-nav mx-auto mb-2 mb-lg-0 justify-content-center">
-                    <li class=" nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'home' %}">Home</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'research' %}">Research</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link active" aria-current="page"  href="#">Members</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'pub' %}">Publications</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'news' %}">News</a>
-                    </li>
-                  </ul>
-              </div>
-              
-            </nav>
+              {% include 'includes/navbar.html' with active='members' %}
 
           </div>                
             

--- a/templates/members/infoMember.html
+++ b/templates/members/infoMember.html
@@ -38,31 +38,7 @@
           <div class="row justify-content-center">
             <div class="col mt-1">
   
-              <nav class="nav navbar-expand-lg ">
-                <button class="navbar-toggler custom-custom-toggler custom-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                    <i class="bi bi-list icon-white"></i>
-                </button>
-                <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                  <ul class="navbar-nav mx-auto mb-2 mb-lg-0 justify-content-center">
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'home' %}">Home</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'research' %}">Research</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link active" aria-current="page" href="{% url 'miembros' %}">Members</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link"  href="{% url 'pub' %}">Publications</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link "  href="{% url 'news' %}">News</a>
-                    </li>
-                  </ul>
-                </div>
-                
-              </nav>
+                {% include 'includes/navbar.html' with active='members' %}
   
             </div>                
               

--- a/templates/members/members.html
+++ b/templates/members/members.html
@@ -37,31 +37,7 @@
         <div class="row justify-content-center">
           <div class="col mt-3">
 
-            <nav class="nav navbar-expand-lg ">
-              <button class="navbar-toggler custom-custom-toggler custom-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                  <i class="bi bi-list icon-white"></i>
-              </button>
-              <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                  <ul class="navbar-nav mx-auto mb-2 mb-lg-0 justify-content-center">
-                    <li class=" nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'home' %}">Home</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'research' %}">Research</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link active" aria-current="page"  href="#">Members</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'pub' %}">Publications</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'news' %}">News</a>
-                    </li>
-                  </ul>
-              </div>
-              
-            </nav>
+              {% include 'includes/navbar.html' with active='members' %}
 
           </div>                
             

--- a/templates/news/new.html
+++ b/templates/news/new.html
@@ -37,31 +37,7 @@
           <div class="row justify-content-center">
             <div class="col mt-1">
   
-              <nav class="nav navbar-expand-lg ">
-                <button class="navbar-toggler custom-custom-toggler custom-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                    <i class="bi bi-list icon-white"></i>
-                </button>
-                <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                  <ul class="navbar-nav mx-auto mb-2 mb-lg-0 justify-content-center">
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'home' %}">Home</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'research' %}">Research</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link"  href="{% url 'miembros' %}">Members</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link"  href="{% url 'pub' %}">Publications</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link active"  aria-current="page" href="{% url 'news' %}">News</a>
-                    </li>
-                  </ul>
-                </div>
-                
-              </nav>
+                {% include 'includes/navbar.html' with active='news' %}
   
             </div>                
               

--- a/templates/news/news.html
+++ b/templates/news/news.html
@@ -37,31 +37,7 @@
           <div class="row justify-content-center">
             <div class="col mt-3">
   
-              <nav class="nav navbar-expand-lg ">
-                <button class="navbar-toggler custom-custom-toggler custom-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                    <i class="bi bi-list icon-white"></i>
-                </button>
-                <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                  <ul class="navbar-nav mx-auto mb-2 mb-lg-0 justify-content-center">
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'home' %}">Home</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'research' %}">Research</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link"  href="{% url 'miembros' %}">Members</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link"  href="{% url 'pub' %}">Publications</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link active"  aria-current="page" href="#">News</a>
-                    </li>
-                  </ul>
-                </div>
-                
-              </nav>
+                {% include 'includes/navbar.html' with active='news' %}
   
             </div>                
               

--- a/templates/publications/publications.html
+++ b/templates/publications/publications.html
@@ -37,31 +37,7 @@
           <div class="row justify-content-center">
             <div class="col mt-3">
   
-              <nav class="nav navbar-expand-lg ">
-                <button class="navbar-toggler custom-custom-toggler custom-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                    <i class="bi bi-list icon-white"></i>
-                </button>
-                <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                    <ul class="navbar-nav mx-auto mb-2 mb-lg-0 justify-content-center">
-                      <li class="nav-item custom-nav-item me-5">
-                        <a class="nav-link" href="{% url 'home' %}">Home</a>
-                      </li>
-                      <li class="nav-item custom-nav-item me-5">
-                        <a class="nav-link" href="{% url 'research' %}">Research</a>
-                      </li>
-                      <li class="nav-item custom-nav-item me-5">
-                        <a class="nav-link"  href="{% url 'miembros' %}">Members</a>
-                      </li>
-                      <li class="nav-item custom-nav-item me-5">
-                        <a class="nav-link active" aria-current="page" href="#">Publications</a>
-                      </li>
-                      <li class="nav-item custom-nav-item me-5">
-                        <a class="nav-link" href="{% url 'news' %}">News</a>
-                      </li>
-                    </ul>
-                </div>
-                
-              </nav>
+                {% include 'includes/navbar.html' with active='publications' %}
   
             </div>                
               

--- a/templates/research/research.html
+++ b/templates/research/research.html
@@ -38,31 +38,7 @@
         <div class="row justify-content-center">
           <div class="col mt-3">
 
-            <nav class="nav navbar-expand-lg ">
-              <button class="navbar-toggler custom-custom-toggler custom-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                  <i class="bi bi-list icon-white"></i>
-              </button>
-              <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                  <ul class="navbar-nav mx-auto mb-2 mb-lg-0 justify-content-center">
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'home' %}">Home</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link active" aria-current="page" href="#">Research</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link"  href="{% url 'miembros' %}">Members</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'pub' %}">Publications</a>
-                    </li>
-                    <li class="nav-item custom-nav-item me-5">
-                      <a class="nav-link" href="{% url 'news' %}">News</a>
-                    </li>
-                  </ul>
-              </div>
-              
-            </nav>
+              {% include 'includes/navbar.html' with active='research' %}
 
           </div>                
             


### PR DESCRIPTION
## Summary
- add a shared `navbar.html` include
- update home and other templates to reuse the navbar include

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68471f169fc48329846f41836ccdc347