### PR TITLE
Add About section with CTA on home page

### DIFF
--- a/static/css/home.css
+++ b/static/css/home.css
@@ -29,3 +29,8 @@
     box-shadow: 5px 5px 20px rgba(0,0,0,0.4);
     transform: translateY(-3%);
 }
+
+#aboutHome {
+    background-color: #f8f9fa;
+    border-radius: 8px;
+}

--- a/templates/homeApp/index.html
+++ b/templates/homeApp/index.html
@@ -65,8 +65,25 @@
 
     </div>
 
-    
-  
+
+    <!--About section-->
+    <div class="container my-5" id="aboutHome">
+      <div class="row justify-content-center">
+        <div class="col-md-8 text-center">
+          <h3 class="mb-3" style="color:#3A7DA4; font-weight: bold;">
+            About us
+          </h3>
+          <p>
+            The Centre for Integrative Ecology (CEI) brings together researchers
+            from diverse disciplines to advance ecological understanding across
+            spatial and temporal scales.
+          </p>
+          <a href="{% url 'research' %}" class="btn btn-primary mt-3" style="background-color:#3A7DA4; border-color:#3A7DA4;">
+            Learn more about our work
+          </a>
+        </div>
+      </div>
+    </div>
 
     <!--Lines of research-->
     <div class="row align-items-center justify-content-evenly mx-5 my-5">


### PR DESCRIPTION
## Summary
- add an informational About block on the home page
- keep hero header and navigation
- style the new block in home.css

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684723a37e88832982ea02d1f6b92284